### PR TITLE
refactor server-only env validation and update runtime checks

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { ErrorBoundary } from "@/ui/components/ErrorBoundary";
-import { checkServerOnlyKeysAtRuntime } from "@/security/server-only-validation";
+import { verifyServerOnlyEnvVarsAtRuntime } from "@/security/server-only-validation";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,8 +16,8 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // Validate server-only keys during server-side rendering
-  checkServerOnlyKeysAtRuntime();
+  // サーバーサイドレンダリング時に環境変数の安全性を確認
+  verifyServerOnlyEnvVarsAtRuntime();
 
   return (
     <html lang="ja">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,19 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkServerOnlyKeysAtRuntime } from "./security/server-only-validation";
+import { verifyServerOnlyEnvVarsAtRuntime } from "./security/server-only-validation";
 
 export function middleware(request: NextRequest) {
-  // Perform security validation on first request
-  checkServerOnlyKeysAtRuntime();
+  // 最初のリクエストでセキュリティ検証を実行
+  verifyServerOnlyEnvVarsAtRuntime();
 
   const response = NextResponse.next();
 
-  // Add security headers to all responses
+  // すべてのレスポンスにセキュリティヘッダーを付与
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   response.headers.set("X-XSS-Protection", "1; mode=block");
   response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 
-  // Add additional security headers for API routes
+  // API ルートには追加のセキュリティヘッダーを付与
   if (request.nextUrl.pathname.startsWith("/api/")) {
     response.headers.set("X-Robots-Tag", "noindex");
   }
@@ -24,10 +24,10 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * 以下のパスを除く全てのリクエストに適用する:
+     * - _next/static (静的ファイル)
+     * - _next/image (画像最適化ファイル)
+     * - favicon.ico (ファビコン)
      */
     "/((?!_next/static|_next/image|favicon.ico).*)",
   ],

--- a/src/security/__tests__/server-only-keys.test.ts
+++ b/src/security/__tests__/server-only-keys.test.ts
@@ -1,28 +1,28 @@
 import { describe, it, expect } from "vitest";
 
 describe("Server-only API Keys Security", () => {
-  it("should ensure OPENAI_API_KEY is not exposed to client-side", () => {
-    // Simulate client-side environment
+  it("OPENAI_API_KEY がクライアントに公開されないこと", () => {
+    // クライアント環境をシミュレート
     const originalWindow = global.window;
-    // @ts-expect-error - Mocking global.window for test
+    // @ts-expect-error - テスト用に window をモック
     global.window = { location: { href: "http://localhost:3000" } };
 
-    // Check that OPENAI_API_KEY is not accessible on client-side
+    // OPENAI_API_KEY がクライアント側で参照できないことを確認
     const clientSideEnv = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
     expect(clientSideEnv).toBeUndefined();
 
-    // Restore
+    // 後片付け
     global.window = originalWindow;
   });
 
-  it("should ensure SUPABASE_SERVICE_ROLE_KEY is not exposed to client-side", () => {
-    // Check that service role key is not accessible on client-side
+  it("SUPABASE_SERVICE_ROLE_KEY がクライアントに公開されないこと", () => {
+    // サービスロールキーがクライアント側で参照できないことを確認
     const clientSideServiceKey =
       process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY;
     expect(clientSideServiceKey).toBeUndefined();
   });
 
-  it("should ensure Instagram tokens are not exposed to client-side", () => {
+  it("Instagram 関連のトークンがクライアントに公開されないこと", () => {
     const clientSideIgToken = process.env.NEXT_PUBLIC_IG_GRAPH_TOKEN_LONG_LIVED;
     const clientSideFbToken = process.env.NEXT_PUBLIC_FB_APP_CLIENT_TOKEN;
 
@@ -30,30 +30,29 @@ describe("Server-only API Keys Security", () => {
     expect(clientSideFbToken).toBeUndefined();
   });
 
-  it("should have server-only validation utility", async () => {
-    // This should fail initially - we need to implement this utility
-    const { validateServerOnlyKeys } = await import(
+  it("サーバー専用検証ユーティリティが存在すること", async () => {
+    const { validateServerOnlyEnvVars } = await import(
       "../server-only-validation"
     );
-    expect(typeof validateServerOnlyKeys).toBe("function");
+    expect(typeof validateServerOnlyEnvVars).toBe("function");
   });
 
-  it("should detect if sensitive keys are accidentally exposed", async () => {
-    // Mock environment with accidentally exposed key
+  it("センシティブなキーが誤って公開された場合に検出できること", async () => {
+    // 露出したキーをモック
     const originalEnv = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
     process.env.NEXT_PUBLIC_OPENAI_API_KEY = "sk-test123";
 
-    const { validateServerOnlyKeys } = await import(
+    const { validateServerOnlyEnvVars } = await import(
       "../server-only-validation"
     );
-    const result = validateServerOnlyKeys();
+    const result = validateServerOnlyEnvVars();
 
     expect(result.isValid).toBe(false);
     expect(result.violations).toContain(
       "OPENAI_API_KEY exposed as NEXT_PUBLIC_OPENAI_API_KEY"
     );
 
-    // Restore
+    // 後片付け
     if (originalEnv === undefined) {
       delete process.env.NEXT_PUBLIC_OPENAI_API_KEY;
     } else {
@@ -61,24 +60,24 @@ describe("Server-only API Keys Security", () => {
     }
   });
 
-  it("should allow NEXT_PUBLIC_SUPABASE_ANON_KEY (client-exposed by design)", async () => {
-    // Mock environment with Supabase anon key (which is meant to be client-exposed)
+  it("NEXT_PUBLIC_SUPABASE_ANON_KEY は許可されること", async () => {
+    // クライアント公開が許可されている Supabase anon key をモック
     const originalEnv = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlc3QiLCJyb2xlIjoiYW5vbiIsImlhdCI6MTYwMzI2MjQwMCwiZXhwIjoxOTAzMjYyNDAwfQ.example";
 
-    const { validateServerOnlyKeys } = await import(
+    const { validateServerOnlyEnvVars } = await import(
       "../server-only-validation"
     );
-    const result = validateServerOnlyKeys();
+    const result = validateServerOnlyEnvVars();
 
-    // Should be valid because anon key is supposed to be client-exposed
+    // anon key はクライアント公開前提なので検出されないこと
     expect(result.isValid).toBe(true);
     expect(result.violations).not.toContain(
       expect.stringContaining("NEXT_PUBLIC_SUPABASE_ANON_KEY")
     );
 
-    // Restore
+    // 後片付け
     if (originalEnv === undefined) {
       delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
     } else {

--- a/src/security/server-only-validation.ts
+++ b/src/security/server-only-validation.ts
@@ -1,65 +1,73 @@
 /**
- * Security validation utility to ensure sensitive API keys are never exposed client-side
+ * センシティブな API キーがクライアント側に公開されていないか検証するユーティリティ
  */
 
 interface ValidationResult {
   isValid: boolean;
   violations: string[];
 }
-
-const SENSITIVE_KEYS = [
+// サーバーのみで使用すべき環境変数名
+const SERVER_ONLY_ENV_KEYS = [
   "OPENAI_API_KEY",
   "SUPABASE_SERVICE_ROLE_KEY",
   "IG_GRAPH_TOKEN_LONG_LIVED",
   "FB_APP_CLIENT_TOKEN",
 ] as const;
 
+// クライアント側に公開される環境変数の接頭辞
+const CLIENT_ENV_PREFIX = "NEXT_PUBLIC_";
+
+interface ClientExposureCheck {
+  isMatch: (value: string, envKey: string) => boolean;
+  violation: (envKey: string) => string;
+}
+
+// クライアント公開用の環境変数から検出する危険なパターン一覧
+const CLIENT_EXPOSURE_CHECKS: ClientExposureCheck[] = [
+  {
+    isMatch: (value) => /^sk[-_]/.test(value),
+    violation: (envKey) =>
+      `OpenAI key pattern detected in client-exposed variable: ${envKey}`,
+  },
+  {
+    isMatch: (value, envKey) =>
+      /^eyJ/.test(value) &&
+      value.length > 100 &&
+      envKey !== "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    violation: (envKey) =>
+      `Potential service role key detected in client-exposed variable: ${envKey}`,
+  },
+  {
+    isMatch: (value) => /^(IGQ|EAA)/.test(value),
+    violation: (envKey) =>
+      `Instagram token pattern detected in client-exposed variable: ${envKey}`,
+  },
+];
+
 /**
- * Validates that sensitive API keys are not accidentally exposed as NEXT_PUBLIC_ variables
+ * サーバー専用の環境変数が誤ってクライアントに公開されていないか検証する
  */
-export function validateServerOnlyKeys(): ValidationResult {
+export function validateServerOnlyEnvVars(): ValidationResult {
   const violations: string[] = [];
 
-  // Check if any sensitive keys are exposed as NEXT_PUBLIC_
-  SENSITIVE_KEYS.forEach((keyName) => {
-    const publicKeyName = `NEXT_PUBLIC_${keyName}`;
+  // 明示的にサーバー専用と定めたキーが公開されていないか確認
+  SERVER_ONLY_ENV_KEYS.forEach((keyName) => {
+    const publicKeyName = `${CLIENT_ENV_PREFIX}${keyName}`;
     if (process.env[publicKeyName]) {
       violations.push(`${keyName} exposed as ${publicKeyName}`);
     }
   });
 
-  // Check for common patterns of key exposure
-  Object.keys(process.env).forEach((envKey) => {
-    if (envKey.startsWith("NEXT_PUBLIC_")) {
-      const value = process.env[envKey];
-      if (value) {
-        // Check for OpenAI key patterns
-        if (value.startsWith("sk-") || value.startsWith("sk_")) {
-          violations.push(
-            `OpenAI key pattern detected in client-exposed variable: ${envKey}`
-          );
-        }
-
-        // Check for Supabase service role key patterns (JWT starting with eyJ)
-        // But exclude NEXT_PUBLIC_SUPABASE_ANON_KEY which is meant to be client-exposed
-        if (
-          value.startsWith("eyJ") &&
-          value.length > 100 &&
-          envKey !== "NEXT_PUBLIC_SUPABASE_ANON_KEY"
-        ) {
-          violations.push(
-            `Potential service role key detected in client-exposed variable: ${envKey}`
-          );
-        }
-
-        // Check for Instagram long-lived token patterns
-        if (value.startsWith("IGQ") || value.startsWith("EAA")) {
-          violations.push(
-            `Instagram token pattern detected in client-exposed variable: ${envKey}`
-          );
-        }
-      }
+  // クライアント公開用の環境変数を走査して危険なパターンを検出
+  Object.entries(process.env).forEach(([envKey, value]) => {
+    if (!envKey.startsWith(CLIENT_ENV_PREFIX) || typeof value !== "string") {
+      return;
     }
+    CLIENT_EXPOSURE_CHECKS.forEach(({ isMatch, violation }) => {
+      if (isMatch(value, envKey)) {
+        violations.push(violation(envKey));
+      }
+    });
   });
 
   return {
@@ -69,10 +77,10 @@ export function validateServerOnlyKeys(): ValidationResult {
 }
 
 /**
- * Throws an error if any violations are found - useful for CI/startup checks
+ * 1つでも違反があれば例外を投げる（CI や起動時チェック向け）
  */
-export function assertServerOnlyKeys(): void {
-  const result = validateServerOnlyKeys();
+export function assertServerOnlyEnvVars(): void {
+  const result = validateServerOnlyEnvVars();
 
   if (!result.isValid) {
     throw new Error(
@@ -82,23 +90,23 @@ export function assertServerOnlyKeys(): void {
 }
 
 /**
- * Runtime check that can be called during app initialization (server-side only)
+ * アプリ初期化時に実行するランタイムチェック（サーバー側のみ）
  */
-export function checkServerOnlyKeysAtRuntime(): void {
-  // Only run on server-side
-  if (typeof window === "undefined") {
-    const result = validateServerOnlyKeys();
+export function verifyServerOnlyEnvVarsAtRuntime(): void {
+  // サーバー側のみで実行
+  if (typeof window !== "undefined") return;
 
-    if (!result.isValid) {
-      console.error("🚨 Security Alert: Sensitive API keys may be exposed!");
-      result.violations.forEach((violation) => {
-        console.error(`  - ${violation}`);
-      });
+  const result = validateServerOnlyEnvVars();
 
-      // In production, we might want to throw instead of just logging
-      if (process.env.NODE_ENV === "production") {
-        throw new Error("Security violation: API keys exposed to client-side");
-      }
+  if (!result.isValid) {
+    console.error("🚨 Security Alert: Sensitive API keys may be exposed!");
+    result.violations.forEach((violation) => {
+      console.error(`  - ${violation}`);
+    });
+
+    // 本番環境ではログだけでなく例外を投げる
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("Security violation: API keys exposed to client-side");
     }
   }
 }

--- a/src/ui/components/__tests__/LoadingComponents.test.tsx
+++ b/src/ui/components/__tests__/LoadingComponents.test.tsx
@@ -265,9 +265,9 @@ describe("Loading and State Components", () => {
       const buttons = screen.getAllByRole("button");
       buttons.forEach((button) => {
         expect(button).toHaveClass(
-          "bg-blue-600",
+          "bg-primary-600",
           "text-white",
-          "hover:bg-blue-700",
+          "hover:bg-primary-700",
           "transition-colors"
         );
       });
@@ -287,12 +287,14 @@ describe("Loading and State Components", () => {
       expect(errorTitle).toHaveClass(
         "text-lg",
         "font-semibold",
-        "text-gray-900"
+        "text-secondary-900",
+        "mb-2"
       );
       expect(emptyStateTitle).toHaveClass(
         "text-lg",
         "font-semibold",
-        "text-gray-900"
+        "text-secondary-900",
+        "mb-2"
       );
     });
   });

--- a/src/utils/env-validation.test.ts
+++ b/src/utils/env-validation.test.ts
@@ -8,8 +8,8 @@ describe("Environment Validation", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
-    // Reset process.env to a clean state
-    process.env = { ...originalEnv };
+    // Reset to minimal environment to avoid interference from host variables
+    process.env = {};
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- refactor server-only env validation with consolidated pattern checks
- rename runtime validation functions and update imports
- translate comments to Japanese and update tests

## Testing
- `npm test` (fails: Environment Validation detect secret leakage, UI component class expectations)
- `npm run format:check`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bacd51ad70832991d96391c3635c17