### PR TITLE
refactor server-only env validation and update runtime checks

### DIFF
--- a/src/ui/components/__tests__/LoadingComponents.test.tsx
+++ b/src/ui/components/__tests__/LoadingComponents.test.tsx
@@ -265,9 +265,9 @@ describe("Loading and State Components", () => {
       const buttons = screen.getAllByRole("button");
       buttons.forEach((button) => {
         expect(button).toHaveClass(
-          "bg-blue-600",
+          "bg-primary-600",
           "text-white",
-          "hover:bg-blue-700",
+          "hover:bg-primary-700",
           "transition-colors"
         );
       });
@@ -287,12 +287,14 @@ describe("Loading and State Components", () => {
       expect(errorTitle).toHaveClass(
         "text-lg",
         "font-semibold",
-        "text-gray-900"
+        "text-secondary-900",
+        "mb-2"
       );
       expect(emptyStateTitle).toHaveClass(
         "text-lg",
         "font-semibold",
-        "text-gray-900"
+        "text-secondary-900",
+        "mb-2"
       );
     });
   });

--- a/src/utils/env-validation.test.ts
+++ b/src/utils/env-validation.test.ts
@@ -8,8 +8,8 @@ describe("Environment Validation", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
-    // Reset process.env to a clean state
-    process.env = { ...originalEnv };
+    // Reset to minimal environment to avoid interference from host variables
+    process.env = {};
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- refactor server-only env validation with consolidated pattern checks
- rename runtime validation functions and update imports
- translate comments to Japanese and update tests
- fix test expectations for primary/secondary color classes and isolate CI env checks

## Testing
- `npm run format:check`
- `npm run lint`
- `npx vitest run src/utils/env-validation.test.ts src/ui/components/__tests__/LoadingComponents.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bad8a83c9c832997853543b55df033